### PR TITLE
workflows: add validation errors callback

### DIFF
--- a/inspirehep/modules/workflows/errors.py
+++ b/inspirehep/modules/workflows/errors.py
@@ -33,3 +33,47 @@ class DownloadError(WorkflowsError):
 class MergeError(WorkflowsError):
 
     """Error representing a failed merge in a workflow."""
+
+
+class CallbackError(WorkflowsError):
+    """Callback exception."""
+
+    code = 400
+    description = 'Workflow callback error.'
+
+
+class CallbackMalformedError(CallbackError):
+    """Malformed request exception."""
+
+    error_code = 'MALFORMED'
+
+    def __init__(self, key, **kwargs):
+        """Initialize exception."""
+        super(CallbackMalformedError, self).__init__(**kwargs)
+        self.description = 'Malformed workflow, "{}" key was not found.'.format(
+            key)
+
+
+class CallbackWorkflowNotFoundError(CallbackError):
+    """Workflow not found exception."""
+
+    code = 404
+    error_code = 'WORKFLOW_NOT_FOUND'
+
+    def __init__(self, workflow_id, **kwargs):
+        """Initialize exception."""
+        super(CallbackWorkflowNotFoundError, self).__init__(**kwargs)
+        self.description = 'The workflow with id "{}" was not found.'.format(
+            workflow_id)
+
+
+class CallbackValidationError(CallbackError):
+    """Validation error exception."""
+
+    error_code = 'VALIDATION_ERROR'
+    description = 'Validation error.'
+
+    def __init__(self, workflow_data, **kwargs):
+        """Initialize exception."""
+        super(CallbackValidationError, self).__init__(**kwargs)
+        self.workflow = workflow_data

--- a/inspirehep/modules/workflows/search.py
+++ b/inspirehep/modules/workflows/search.py
@@ -43,8 +43,10 @@ def holdingpen_search_factory(self, search, **kwargs):
         'metadata.acquisition_source', 'metadata.arxiv_eprints',
         'metadata.arxiv_categories', '_workflow',
         '_extra_data.relevance_prediction', '_extra_data.user_action',
-        '_extra_data.classifier_results.complete_output', '_extra_data.journal_coverage',
-        '_extra_data._action', '_extra_data.matches',
+        '_extra_data.classifier_results.complete_output',
+        '_extra_data.journal_coverage', '_extra_data._action',
+        '_extra_data.matches', '_extra_data.validation_errors',
+        '_extra_data.callback_url',
     ]
     search = search.extra(_source={"include": includes})
     return search, urlkwargs

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -20,14 +20,15 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Tasks related to user actions."""
-
 from __future__ import absolute_import, division, print_function
 
+import sys
 import re
 from functools import wraps
+from six import reraise
 
 from flask import current_app
+from jsonschema.exceptions import ValidationError
 from sqlalchemy import (
     JSON,
     String,
@@ -41,25 +42,25 @@ from invenio_db import db
 from invenio_workflows import ObjectStatus
 from invenio_workflows.errors import WorkflowsError
 from invenio_records.models import RecordMetadata
-
 from inspire_schemas.builders import LiteratureBuilder
 from inspire_schemas.utils import validate
 from inspire_utils.record import get_value
 from inspirehep.modules.records.json_ref_loader import replace_refs
 from inspirehep.modules.workflows.tasks.refextract import (
     extract_references_from_pdf,
-    extract_references_from_text,
     extract_references_from_raw_refs,
+    extract_references_from_text,
 )
 from inspirehep.modules.workflows.utils import (
     download_file_to_workflow,
     get_document_in_workflow,
     log_workflows_action,
+    resolve_validation_callback_url,
+    validation_errors,
     with_debug_logging,
 )
 from inspirehep.utils.normalizers import normalize_journal_title
 from inspirehep.utils.url import is_pdf_link
-
 
 RE_ALPHANUMERIC = re.compile('\W+', re.UNICODE)
 
@@ -245,7 +246,16 @@ def validate_record(schema):
     @with_debug_logging
     @wraps(validate_record)
     def _validate_record(obj, eng):
-        validate(obj.data, schema)
+        try:
+            validate(obj.data, schema)
+        except ValidationError:
+            obj.extra_data['validation_errors'] = \
+                validation_errors(obj.data, schema)
+            obj.extra_data['callback_url'] = \
+                resolve_validation_callback_url()
+            obj.save()
+            db.session.commit()
+            reraise(*sys.exc_info())
 
     _validate_record.__doc__ = 'Validate the workflow record against the "%s" schema.' % schema
     return _validate_record

--- a/inspirehep/modules/workflows/utils/__init__.py
+++ b/inspirehep/modules/workflows/utils/__init__.py
@@ -30,13 +30,14 @@ import os
 import traceback
 from contextlib import closing, contextmanager
 from functools import wraps
-
+from six import text_type
 import backoff
 import lxml.etree as ET
 import requests
-from flask import current_app
+from flask import current_app, url_for
 
 from invenio_db import db
+from inspire_schemas.utils import get_validation_errors
 
 from inspirehep.utils.url import retrieve_uri
 from inspirehep.modules.workflows.models import (
@@ -269,3 +270,38 @@ def insert_wf_record_source(json, record_uuid, source):
     else:
         record_source.json = json
     db.session.commit()
+
+
+def resolve_validation_callback_url():
+    """Resolve validation callback.
+
+    Returns the callback url for resolving the validation errors.
+
+    Note:
+        It's using ``inspire_workflows.callback_resolve_validation``
+        route.
+    """
+    return url_for(
+        'inspire_workflows.callback_resolve_validation',
+        _external=True
+    )
+
+
+def validation_errors(data, schema):
+    """Creates a ``validation_errors`` dictionary.
+
+    Args:
+        data (dict): the object to validate.
+        schema (str): the name of the schema.
+
+    Returns:
+        dict: ``validation_errors`` formatted dict.
+    """
+    errors = get_validation_errors(data, schema=schema)
+    error_messages = [
+        {
+            'path': map(lambda path: text_type(path), error.absolute_path),
+            'message': text_type(error.message),
+        } for error in errors
+    ]
+    return error_messages

--- a/tests/integration/workflows/helpers/calls.py
+++ b/tests/integration/workflows/helpers/calls.py
@@ -193,3 +193,30 @@ def core_record():
     assert categories
 
     return json_data, categories
+
+
+def do_validation_callback(app, worfklow_id, metadata,
+                           extra_data, malformed=False):
+    """Do a validation callback request.
+
+       Note:
+           If ``malformed`` is true it will make the payload
+           invalid, by removing two required ``keys``; ``id``
+           and ``_extra_data``.
+    """
+    client = app.test_client()
+    payload = {
+        'id': worfklow_id,
+        'metadata': metadata,
+        '_extra_data': extra_data
+    }
+
+    if malformed:
+        payload.pop('_extra_data', None)
+        payload.pop('id', None)
+
+    return client.put(
+        '/callback/workflows/resolve_validation_errors',
+        data=json.dumps(payload),
+        content_type='application/json',
+    )

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -24,6 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import json
 import mock
 import pytest
 
@@ -41,14 +42,15 @@ from jsonschema import ValidationError
 from calls import (
     core_record,
     do_accept_core,
-    do_webcoll_callback,
-    do_robotupload_callback,
     do_resolve_matching,
+    do_robotupload_callback,
+    do_validation_callback,
+    do_webcoll_callback,
     generate_record,
 )
 from mocks import (
-    fake_download_file,
     fake_beard_api_request,
+    fake_download_file,
     fake_magpie_api_request,
 )
 from utils import get_halted_workflow
@@ -483,6 +485,13 @@ def test_article_workflow_stops_when_record_is_not_valid(workflow_app):
     assert '_error_msg' in obj.extra_data
     assert 'required' in obj.extra_data['_error_msg']
 
+    expected_url = 'http://localhost:5000/callback/workflows/resolve_validation_errors'
+
+    assert expected_url == obj.extra_data['callback_url']
+    assert obj.extra_data['validation_errors']
+    assert 'message' in obj.extra_data['validation_errors'][0]
+    assert 'path' in obj.extra_data['validation_errors'][0]
+
 
 def test_article_workflow_continues_when_record_is_valid(workflow_app):
     valid_record = {
@@ -504,6 +513,15 @@ def test_article_workflow_continues_when_record_is_valid(workflow_app):
 
     assert obj.status != ObjectStatus.ERROR
     assert '_error_msg' not in obj.extra_data
+
+    response = do_validation_callback(
+        workflow_app,
+        obj.id,
+        obj.data,
+        obj.extra_data
+    )
+
+    assert response.status_code == 200
 
 
 @mock.patch(
@@ -633,3 +651,167 @@ def test_fuzzy_matched_goes_trough_the_workflow(
     assert obj.extra_data['is-update']
     assert obj.extra_data['approved']
     assert obj.status == ObjectStatus.COMPLETED
+
+
+def test_validation_error_callback_valid(workflow_app):
+    invalid_record = {
+        '_collections': [
+            'Literature',
+        ],
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'A title'},
+        ],
+        'preprint_date': 'Jessica Jones'
+    }
+
+    obj = workflow_object_class.create(
+        data=invalid_record,
+        data_type='hep',
+        id_user=1,
+    )
+    obj_id = obj.id
+
+    with pytest.raises(ValidationError):
+        start('article', invalid_record, obj_id)
+
+    response = do_validation_callback(
+        workflow_app,
+        obj_id,
+        obj.data,
+        obj.extra_data
+    )
+
+    obj = workflow_object_class.get(obj_id)
+
+    assert obj.status == ObjectStatus.ERROR
+    assert response.status_code == 400
+
+    obj = workflow_object_class.get(obj_id)
+    obj.data['preprint_date'] = '2018'
+    obj.save()
+    db.session.commit()
+
+    response = do_validation_callback(
+        workflow_app,
+        obj_id,
+        obj.data,
+        obj.extra_data
+    )
+    assert response.status_code == 200
+
+    obj = workflow_object_class.get(obj_id)
+    assert obj.status != ObjectStatus.ERROR
+
+
+def test_validation_error_callback_with_validation_error(workflow_app):
+    invalid_record = {
+        '_collections': [
+            'Literature',
+        ],
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'A title'},
+        ],
+        'preprint_date': 'Jessica Jones'
+    }
+
+    obj = workflow_object_class.create(
+        data=invalid_record,
+        data_type='hep',
+        id_user=1,
+    )
+    obj_id = obj.id
+
+    with pytest.raises(ValidationError):
+        start('article', invalid_record, obj_id)
+
+    response = do_validation_callback(
+        workflow_app,
+        obj.id,
+        obj.data,
+        obj.extra_data
+    )
+
+    expected_message = 'Validation error.'
+    expected_error_code = 'VALIDATION_ERROR'
+    data = json.loads(response.get_data())
+
+    assert response.status_code == 400
+    assert expected_error_code == data['error_code']
+    assert expected_message == data['message']
+
+    assert data['workflow']['_extra_data']['callback_url']
+    assert len(data['workflow']['_extra_data']['validation_errors']) == 1
+
+
+def test_validation_error_callback_with_missing_worfklow(workflow_app):
+    invalid_record = {
+        '_collections': [
+            'Literature',
+        ],
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'A title'},
+        ],
+    }
+
+    eng_uuid = start('article', [invalid_record])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+    obj.id = 1111
+    response = do_validation_callback(
+        workflow_app,
+        obj.id,
+        obj.data,
+        obj.extra_data
+    )
+    data = json.loads(response.get_data())
+    expected_message = 'The workflow with id "1111" was not found.'
+    expected_error_code = 'WORKFLOW_NOT_FOUND'
+
+    assert response.status_code == 404
+    assert expected_error_code == data['error_code']
+    assert expected_message == data['message']
+
+
+def test_validation_error_callback_with_malformed(workflow_app):
+    invalid_record = {
+        '_collections': [
+            'Literature',
+        ],
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'A title'},
+        ],
+    }
+
+    eng_uuid = start('article', [invalid_record])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+    obj.id = 1111
+
+    response = do_validation_callback(
+        workflow_app,
+        obj.id,
+        obj.data,
+        obj.extra_data,
+        malformed=True
+    )
+    data = json.loads(response.get_data())
+    expected_message = 'Malformed workflow, "_extra_data" key was not found.'
+    expected_error_code = 'MALFORMED'
+
+    assert response.status_code == 400
+    assert expected_error_code == data['error_code']
+    assert expected_message == data['message']


### PR DESCRIPTION
* Adds a callback endpoint for the UI, this will allow the UI to run
  validation and continue the workflow if the record is valid.

* Adds in ``extra_data`` ``callback_url`` and
  ``validation_errors`` fields on callback request and when validation
  task runs.

Signed-off-by: David Caro <david@dcaro.es>
Co-authored-by: Harris Tzovanakis <me@drjova.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
